### PR TITLE
Distribution: npx support, HTTP transport, and CI/release workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,20 @@
 # All settings are OPTIONAL. The server runs with zero configuration.
 # Copy this file to `.env` only if you want to override a default.
 
-# --- Signing web server ---
+# --- Transport ---
+# stdio (default) for local clients, or http to serve MCP over Streamable HTTP
+# at /mcp alongside the signing page (for remote/web clients).
+# MCP_TRANSPORT=stdio
+
+# --- Web server (signing page + /mcp in http mode) ---
 # PORT=3000
-# HOST=127.0.0.1
-# Set PUBLIC_BASE_URL when the signing page is reachable at a non-localhost URL.
+# HOST=127.0.0.1            # set 0.0.0.0 to expose remotely
+# Set PUBLIC_BASE_URL when the server is reachable at a non-localhost URL.
 # PUBLIC_BASE_URL=http://localhost:3000
+
+# When exposing http mode publicly, enable DNS-rebinding protection:
+# MCP_ALLOWED_HOSTS=your-host.example
+# MCP_ALLOWED_ORIGINS=https://your-host.example
 
 # --- Defaults ---
 # Default chain when a tool call omits chainId (11155111 = Sepolia testnet).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      # `npm ci` runs the `prepare` script, which builds the project.
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+# Publishes to npm when you create a GitHub Release.
+# Requires an `NPM_TOKEN` repository secret (an npm automation token).
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # enables npm provenance
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      # `npm publish` re-runs `prepare` (build) and publishes the version in package.json.
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ coverage/
 build/
 dist/
 
+# npm pack output
+*.tgz
+
 # misc
 .DS_Store
 .env

--- a/README.md
+++ b/README.md
@@ -174,6 +174,18 @@ npm test           # run the test suite (node:test)
 npm run typecheck  # type-check without emitting
 ```
 
+### Releasing
+
+CI (build + tests) runs on every push and PR. To publish a new version to npm:
+
+1. Add an `NPM_TOKEN` repository secret (an npm automation token) — once.
+2. Bump the version and tag: `npm version patch` (or `minor` / `major`), then
+   `git push --follow-tags`.
+3. Create a GitHub Release for that tag. The release workflow runs the tests and
+   publishes to npm (with provenance).
+
+You can also publish manually: `npm publish`.
+
 ## Security
 
 - **Private keys never reach the server.** It only prepares transactions; the

--- a/README.md
+++ b/README.md
@@ -34,23 +34,17 @@ touching private keys. This server solves it by splitting the work:
 
 ## Quick start
 
-Requirements: **Node.js 18+**. That's it.
+Requirements: **Node.js 18+**. No clone, no build, no API keys.
 
-```bash
-git clone https://github.com/zhangzhongnan928/mcp-blockchain-server.git
-cd mcp-blockchain-server
-npm install      # builds automatically
-```
-
-Then register it with your MCP client. For **Claude Desktop**, add this to
-`claude_desktop_config.json` (Settings → Developer → Edit Config):
+Add the server to any MCP client that launches stdio servers. For **Claude
+Desktop**, open Settings → Developer → Edit Config and add:
 
 ```json
 {
   "mcpServers": {
     "blockchain": {
-      "command": "node",
-      "args": ["/absolute/path/to/mcp-blockchain-server/build/index.js"]
+      "command": "npx",
+      "args": ["-y", "mcp-blockchain-server"]
     }
   }
 }
@@ -62,6 +56,51 @@ assistant returns a link — open it, review, and sign in your wallet.
 
 No configuration is required: the server ships with free public RPC endpoints
 and defaults to the **Sepolia testnet**.
+
+### Use it in other clients
+
+The same `npx` command works anywhere that runs an MCP stdio server — the config
+shape is identical across clients:
+
+```json
+{ "command": "npx", "args": ["-y", "mcp-blockchain-server"] }
+```
+
+This is the block to drop into **Cursor** (`.cursor/mcp.json`), **Cline**,
+**Windsurf**, **VS Code** (`.vscode/mcp.json`), and others. To pass options, add
+an `"env"` block (see [Configuration](#configuration)).
+
+### Run from source (development)
+
+```bash
+git clone https://github.com/zhangzhongnan928/mcp-blockchain-server.git
+cd mcp-blockchain-server
+npm install      # installs and builds (via the prepare script)
+```
+
+Then point the client at the build instead of npx:
+
+```json
+{ "command": "node", "args": ["/absolute/path/to/mcp-blockchain-server/build/index.js"] }
+```
+
+### Remote / web clients (HTTP transport)
+
+For MCP clients that connect over HTTP instead of spawning a local process, run
+the server in HTTP mode. It then serves the MCP endpoint **and** the signing
+page on one port:
+
+```bash
+MCP_TRANSPORT=http PUBLIC_BASE_URL=https://your-host npx -y mcp-blockchain-server
+```
+
+- MCP endpoint (Streamable HTTP): `https://your-host/mcp`
+- Signing links: `https://your-host/tx/<id>`
+
+Bind a public interface with `HOST=0.0.0.0` (or keep the default `127.0.0.1` and
+put it behind a reverse proxy). When exposed publicly, set `MCP_ALLOWED_HOSTS`
+and/or `MCP_ALLOWED_ORIGINS` to enable DNS-rebinding protection, and front it
+with HTTPS and access control.
 
 ## Tools
 
@@ -106,15 +145,18 @@ Everything is optional. Copy `.env.example` to `.env` to override defaults.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `PORT` | `3000` | Port for the signing web server. |
-| `HOST` | `127.0.0.1` | Interface to bind (localhost only by default). |
-| `PUBLIC_BASE_URL` | `http://localhost:<PORT>` | Base URL used in signing links (set when hosting remotely). |
+| `MCP_TRANSPORT` | `stdio` | `stdio` for local clients, or `http` to serve MCP over Streamable HTTP at `/mcp`. |
+| `PORT` | `3000` | Port for the signing web server (and the `/mcp` endpoint in http mode). |
+| `HOST` | `127.0.0.1` | Interface to bind (localhost only by default). Set `0.0.0.0` to expose remotely. |
+| `PUBLIC_BASE_URL` | `http://localhost:<PORT>` | Base URL used in signing links and the `/mcp` URL (set when hosting remotely). |
 | `DEFAULT_CHAIN_ID` | `11155111` | Default chain (Sepolia testnet). |
 | `LOG_LEVEL` | `info` | `error` \| `warn` \| `info` \| `debug` (logs go to stderr). |
 | `MCP_DATA_DIR` | `~/.mcp-blockchain` | Where pending transactions are stored. |
 | `RPC_URL_<chainId>` | built-in public RPC | Override the RPC for a chain, e.g. `RPC_URL_1=https://…`. |
 | `INFURA_API_KEY` | — | If set, upgrades default RPCs to Infura. |
 | `ETHERSCAN_API_KEY` | — | If set, `read-contract` can auto-fetch verified ABIs. |
+| `MCP_ALLOWED_HOSTS` | — | Comma-separated Host allowlist for http mode (enables DNS-rebind protection). |
+| `MCP_ALLOWED_ORIGINS` | — | Comma-separated Origin allowlist for http mode (enables DNS-rebind protection). |
 
 ## Supported chains
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -88,5 +88,14 @@ Base URL: `PUBLIC_BASE_URL` (default `http://localhost:3000`).
 | `POST /api/tx/:id/rejected` | Marks a pending tx rejected. |
 | `GET /tx/:id` | The HTML signing page. |
 | `GET /` | A minimal landing page. |
+| `POST /GET /DELETE /mcp` | MCP Streamable HTTP endpoint (only relevant in `MCP_TRANSPORT=http`). |
 
 Errors are returned as `{ "error": "message" }` with an appropriate HTTP status.
+
+## MCP over HTTP
+
+When `MCP_TRANSPORT=http`, the MCP protocol is available at `/mcp` using the
+Streamable HTTP transport. Connect a client to `<PUBLIC_BASE_URL>/mcp`; an
+`initialize` request opens a session returned in the `Mcp-Session-Id` header,
+which subsequent requests must include. This is in addition to the tools above —
+the same five tools are exposed regardless of transport.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,11 +2,25 @@
 
 The server is a **single Node.js process** that exposes two interfaces:
 
-1. An **MCP server over stdio** — what the AI assistant talks to.
+1. An **MCP server** — what the AI assistant talks to. It runs over **stdio**
+   (default, for local clients) or **Streamable HTTP** at `/mcp` (for
+   remote/web clients), selected with `MCP_TRANSPORT`.
 2. An **embedded HTTP server** — serves the transaction signing page and the
-   small API that page uses.
+   small API that page uses. In HTTP transport mode it also hosts `/mcp`, so
+   MCP and signing share one port.
 
 There is no database, cache, message queue, or separate frontend.
+
+## Transports
+
+| Mode (`MCP_TRANSPORT`) | MCP interface | Used by |
+| --- | --- | --- |
+| `stdio` (default) | stdin/stdout of the subprocess | Local clients that launch the server (Claude Desktop, Cursor, …). |
+| `http` | `POST/GET/DELETE /mcp` (Streamable HTTP, session-based) | Remote/web clients; one hosted instance. |
+
+In both modes the signing page is served over HTTP. `src/http/mcpHttp.ts`
+implements the stateful Streamable HTTP transport: an `initialize` request opens
+a session (returned via the `Mcp-Session-Id` header) that later requests reuse.
 
 ```
             stdio (MCP)                         HTTP (localhost)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,20 +7,10 @@ assistant.
 
 - **Node.js 18 or higher** (nothing else — no database, no Redis, no API keys).
 
-## Install
-
-```bash
-git clone https://github.com/zhangzhongnan928/mcp-blockchain-server.git
-cd mcp-blockchain-server
-npm install
-```
-
-`npm install` compiles the TypeScript to `build/` automatically (via the
-`prepare` script). To rebuild later, run `npm run build`.
-
 ## Connect to an MCP client
 
 The server speaks MCP over stdio, so an MCP client launches it as a subprocess.
+The published package runs directly with `npx` — no clone or build required.
 
 ### Claude Desktop
 
@@ -30,15 +20,50 @@ Open **Settings → Developer → Edit Config** and add:
 {
   "mcpServers": {
     "blockchain": {
-      "command": "node",
-      "args": ["/absolute/path/to/mcp-blockchain-server/build/index.js"]
+      "command": "npx",
+      "args": ["-y", "mcp-blockchain-server"]
     }
   }
 }
 ```
 
-Use an **absolute** path to `build/index.js`. Restart Claude Desktop; the
-blockchain tools appear in the tools menu.
+Restart Claude Desktop; the blockchain tools appear in the tools menu.
+
+### Other clients
+
+The same block works in any client that launches stdio MCP servers — Cursor
+(`.cursor/mcp.json`), Cline, Windsurf, VS Code (`.vscode/mcp.json`), and others:
+
+```json
+{ "command": "npx", "args": ["-y", "mcp-blockchain-server"] }
+```
+
+### Remote / HTTP clients
+
+For clients that connect over HTTP rather than spawning a subprocess, run the
+server in HTTP mode (it serves MCP at `/mcp` and the signing page on one port):
+
+```bash
+MCP_TRANSPORT=http PUBLIC_BASE_URL=https://your-host npx -y mcp-blockchain-server
+```
+
+Point the client at `https://your-host/mcp`. Use `HOST=0.0.0.0` to bind a public
+interface (or keep `127.0.0.1` behind a reverse proxy), and set
+`MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` when exposing it publicly.
+
+### Run from source
+
+```bash
+git clone https://github.com/zhangzhongnan928/mcp-blockchain-server.git
+cd mcp-blockchain-server
+npm install   # installs and builds via the prepare script
+```
+
+Then point the client at the build:
+
+```json
+{ "command": "node", "args": ["/absolute/path/to/mcp-blockchain-server/build/index.js"] }
+```
 
 ### Passing configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-blockchain-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-blockchain-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-blockchain-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A self-contained MCP server that lets AI assistants read blockchain data and prepare transactions, while users keep full custody of their keys and sign in their own wallet.",
   "main": "build/index.js",
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,16 @@ function parsePort(value: string | undefined, fallback: number): number {
   return Number.isInteger(parsed) && parsed > 0 && parsed < 65536 ? parsed : fallback;
 }
 
+/** Current server version (single source of truth). */
+export const VERSION = '0.3.0';
+
+function parseList(value: string | undefined): string[] {
+  return (value || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 const port = parsePort(process.env.PORT, 3000);
 
 // Where the signing page is reachable. Defaults to localhost; override
@@ -39,6 +49,18 @@ export const config = {
   etherscanApiKey: process.env.ETHERSCAN_API_KEY || '',
   /** Optional Infura key, used to upgrade default public RPCs when present. */
   infuraApiKey: process.env.INFURA_API_KEY || '',
+  /**
+   * Which MCP transport to expose:
+   *  - "stdio" (default): the process is launched by a local client; MCP runs
+   *    over stdio. The signing server still runs for local links.
+   *  - "http": the process is a long-running server; MCP is served over
+   *    Streamable HTTP at /mcp alongside the signing page.
+   */
+  transport: process.env.MCP_TRANSPORT === 'http' ? ('http' as const) : ('stdio' as const),
+  /** Allowed Host header values for the HTTP transport (enables DNS-rebind protection when set). */
+  mcpAllowedHosts: parseList(process.env.MCP_ALLOWED_HOSTS),
+  /** Allowed Origin values for the HTTP transport (enables DNS-rebind protection when set). */
+  mcpAllowedOrigins: parseList(process.env.MCP_ALLOWED_ORIGINS),
 } as const;
 
 export type AppConfig = typeof config;

--- a/src/http/mcpHttp.ts
+++ b/src/http/mcpHttp.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from 'node:crypto';
+import type { Express, Request, Response } from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { config } from '../config.js';
+import { logger } from '../logger.js';
+import { createMcpServer } from '../mcp/server.js';
+
+/**
+ * Mounts the MCP Streamable HTTP transport at `/mcp` on an existing Express
+ * app, so remote/web MCP clients can use the server over HTTP (in addition to,
+ * or instead of, stdio). Uses the standard stateful pattern: an `initialize`
+ * request creates a session; later requests carry the `mcp-session-id` header.
+ */
+
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+function setCors(res: Response): void {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id, mcp-protocol-version');
+  res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+}
+
+export function mountMcpEndpoint(app: Express): void {
+  app.options('/mcp', (_req, res) => {
+    setCors(res);
+    res.sendStatus(204);
+  });
+
+  app.post('/mcp', async (req: Request, res: Response) => {
+    setCors(res);
+    try {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      let transport = sessionId ? transports.get(sessionId) : undefined;
+
+      if (!transport) {
+        // A new session may only begin with an `initialize` request.
+        if (sessionId || !isInitializeRequest(req.body)) {
+          res.status(400).json({
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'No valid session. Send an initialize request first.' },
+            id: null,
+          });
+          return;
+        }
+
+        const dnsProtection = config.mcpAllowedHosts.length > 0 || config.mcpAllowedOrigins.length > 0;
+        const newTransport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          enableDnsRebindingProtection: dnsProtection,
+          allowedHosts: dnsProtection ? config.mcpAllowedHosts : undefined,
+          allowedOrigins: dnsProtection ? config.mcpAllowedOrigins : undefined,
+          onsessioninitialized: (sid) => {
+            transports.set(sid, newTransport);
+            logger.info(`MCP HTTP session opened: ${sid}`);
+          },
+        });
+        newTransport.onclose = () => {
+          const sid = newTransport.sessionId;
+          if (sid && transports.delete(sid)) logger.info(`MCP HTTP session closed: ${sid}`);
+        };
+
+        await createMcpServer().connect(newTransport);
+        transport = newTransport;
+      }
+
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      logger.error('Error handling MCP POST', error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    }
+  });
+
+  // GET (SSE stream) and DELETE (session teardown) reuse the session transport.
+  const handleSession = async (req: Request, res: Response) => {
+    setCors(res);
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    const transport = sessionId ? transports.get(sessionId) : undefined;
+    if (!transport) {
+      res.status(400).send('Invalid or missing session ID');
+      return;
+    }
+    await transport.handleRequest(req, res);
+  };
+  app.get('/mcp', handleSession);
+  app.delete('/mcp', handleSession);
+
+  logger.info('Mounted MCP Streamable HTTP endpoint at /mcp');
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -10,6 +10,7 @@ import {
   markSubmitted,
 } from '../services/transactionService.js';
 import { renderIndexPage, renderSigningPage } from './signingPage.js';
+import { mountMcpEndpoint } from './mcpHttp.js';
 
 /** Shapes a chain for the browser, including MetaMask `wallet_addEthereumChain` params. */
 function chainView(chain: Chain) {
@@ -52,7 +53,10 @@ function txView(id: string) {
 export function createApp(): express.Express {
   const app = express();
   app.disable('x-powered-by');
-  app.use(express.json({ limit: '256kb' }));
+  app.use(express.json({ limit: '1mb' }));
+
+  // MCP over Streamable HTTP, for remote/web clients (alongside stdio).
+  mountMcpEndpoint(app);
 
   // Baseline security headers for every response.
   app.use((_req: Request, res: Response, next: NextFunction) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,42 @@
 #!/usr/bin/env node
 import type http from 'node:http';
-import { config } from './config.js';
+import { config, VERSION } from './config.js';
 import { logger } from './logger.js';
 import { initStore } from './store.js';
 import { startHttpServer } from './http/server.js';
-import { startMcpServer } from './mcp/server.js';
+import { startStdioServer } from './mcp/server.js';
 import { closeAllProviders } from './blockchain.js';
 
 async function main(): Promise<void> {
-  logger.info('Starting MCP Blockchain Server v0.2.0');
+  logger.info(`Starting MCP Blockchain Server v${VERSION} (transport: ${config.transport})`);
 
   // Load any persisted (pending) transactions.
   await initStore();
 
-  // Start the embedded signing server. A bind failure (e.g. port in use) is
-  // non-fatal: the read-only MCP tools keep working, only signing links break.
+  // The HTTP server hosts the signing page and the MCP-over-HTTP endpoint.
+  // In stdio mode a bind failure is non-fatal (read-only tools still work via
+  // stdio, only signing links break). In http mode it is the only transport,
+  // so a bind failure is fatal.
   let httpServer: http.Server | undefined;
   try {
     httpServer = await startHttpServer();
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    if (config.transport === 'http') {
+      throw new Error(`Could not start HTTP server on ${config.host}:${config.port}: ${detail}`);
+    }
     logger.warn(
-      `Could not start signing server on ${config.host}:${config.port} ` +
-        `(${error instanceof Error ? error.message : String(error)}). ` +
+      `Could not start signing server on ${config.host}:${config.port} (${detail}). ` +
         'Read-only tools still work; set PORT to a free port to enable signing links.',
     );
   }
 
-  // Connect the MCP server over stdio (this is what the AI client talks to).
-  await startMcpServer();
+  // Connect the stdio transport unless we are running as an HTTP server.
+  if (config.transport === 'stdio') {
+    await startStdioServer();
+  } else {
+    logger.info(`MCP available over HTTP at ${config.publicBaseUrl}/mcp`);
+  }
 
   let shuttingDown = false;
   const shutdown = async (signal: string) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { config } from '../config.js';
+import { config, VERSION } from '../config.js';
 import { getChains } from '../chains.js';
 import { getBalance } from '../services/accountService.js';
 import { readContract } from '../services/contractService.js';
@@ -11,12 +11,7 @@ import {
 } from '../services/transactionService.js';
 import { logger } from '../logger.js';
 
-export const server = new McpServer({
-  name: 'mcp-blockchain-server',
-  version: '0.2.0',
-});
-
-/** Wraps a tool handler so any thrown error becomes a clean MCP error result. */
+/** Formats a successful text result for an MCP tool. */
 function text(value: string) {
   return { content: [{ type: 'text' as const, text: value }] };
 }
@@ -29,7 +24,7 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function registerTools(): void {
+function registerTools(server: McpServer): void {
   server.registerTool(
     'get-chains',
     {
@@ -179,14 +174,20 @@ function registerTools(): void {
     },
   );
 
-  logger.info('Registered MCP tools');
+  logger.debug('Registered MCP tools');
 }
 
-/** Registers tools and connects the server over stdio. */
-export async function startMcpServer(): Promise<McpServer> {
-  registerTools();
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+/** Creates a fresh MCP server instance with all tools registered. */
+export function createMcpServer(): McpServer {
+  const server = new McpServer({ name: 'mcp-blockchain-server', version: VERSION });
+  registerTools(server);
+  return server;
+}
+
+/** Creates a server and connects it over stdio (for local MCP clients). */
+export async function startStdioServer(): Promise<McpServer> {
+  const server = createMcpServer();
+  await server.connect(new StdioServerTransport());
   logger.info('MCP server connected over stdio');
   return server;
 }


### PR DESCRIPTION
Makes the server easy to use in **any** MCP client, without a local checkout.

## Highlights

### `npx` distribution (zero install)
The package was already publish-clean (`bin` + `prepare` + `files`), so any stdio MCP client can run it with no clone/build. Docs now lead with:

```json
{ "mcpServers": { "blockchain": { "command": "npx", "args": ["-y", "mcp-blockchain-server"] } } }
```

The same block is documented for Cursor, Cline, Windsurf, and VS Code. (Goes live after the first `npm publish` — the name `mcp-blockchain-server` is currently free.)

### HTTP (Streamable) transport for remote/web clients
`MCP_TRANSPORT=http` serves MCP over the Streamable HTTP transport at `/mcp`, on the **same** Express server that hosts the signing page (one port for both):

```bash
MCP_TRANSPORT=http PUBLIC_BASE_URL=https://your-host npx -y mcp-blockchain-server
```

- Stateful sessions via the `mcp-session-id` header; a fresh MCP server is created per session through a new `createMcpServer()` factory.
- Permissive CORS (exposes `Mcp-Session-Id`) for browser-based clients.
- Optional DNS-rebinding protection via `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS`.
- **stdio remains the default**; `index.ts` is transport-aware (HTTP bind failure is fatal only in http mode).

### CI + release automation
- `.github/workflows/ci.yml` — build (via `npm ci` → `prepare`) + typecheck + tests on push/PR.
- `.github/workflows/release.yml` — publishes to npm **with provenance** when a GitHub Release is published (needs an `NPM_TOKEN` secret).
- Synced `package-lock.json` to 0.3.0 so `npm ci` is reproducible.

### Housekeeping
- Centralized the version (`VERSION` in `config.ts`); bumped to **0.3.0**.
- Ignore `*.tgz` (stray `npm pack` output).
- Documented transports and the release process across the README and `docs/`.

## RPC endpoints (FYI)
Defaults are **free public RPCs** (publicnode.com) — no API keys are embedded anywhere. Resolution order per chain: `RPC_URL_<id>` override → user's `INFURA_API_KEY` → built-in public RPC.

## Verification
- stdio handshake ✓ and HTTP handshake via the SDK client (session + `tools/list` + tool calls) ✓
- Signing page served in both transport modes ✓
- `npm run build` / `typecheck` ✓, `npm test` → **7/7** ✓
- Packed the tarball, installed it into a clean project, and ran the linked `bin` through an MCP init — i.e. the exact `npx` path — ✓

## After merge — to publish
```bash
npm login          # prompts for OTP if 2FA is on
npm publish        # claims the name and builds via `prepare`
```
Or add the `NPM_TOKEN` secret and cut a GitHub Release to let CI publish.

https://claude.ai/code/session_0172kpnvEaam8ssndbN1JYNY

---
_Generated by [Claude Code](https://claude.ai/code/session_0172kpnvEaam8ssndbN1JYNY)_