### PR TITLE
Fix local signing-link failures: port collisions + IPv4/IPv6 localhost split (v0.4.0)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,7 +111,10 @@ interact through an MCP client rather than directly.
 - **Tools don't appear in the client.** Check the path in the config is
   absolute and that `build/index.js` exists (`npm run build`). Check the
   client's MCP logs — this server writes diagnostics to stderr.
-- **"Port already in use."** Another process holds port 3000. Set `PORT` to a
-  free port. Read-only tools still work even if the signing server can't bind.
+- **Signing link shows a 404 / wrong app.** Something else (often a Next.js or
+  other dev server) is on the signing port. In local mode the server now
+  auto-shifts to the next free port and builds the link from it, so this should
+  resolve itself — but if you pinned `PORT`/`PUBLIC_BASE_URL`, make sure that
+  port is actually free (or unset them to let it auto-pick).
 - **A signing link won't open.** Make sure the same server process is still
   running; the link points at its local HTTP server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-blockchain-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-blockchain-server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "node build/index.js",
     "dev": "tsx watch src/index.ts",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test src/**/*.test.ts",
+    "test": "node --import tsx --test $(find src -name '*.test.ts')",
     "prepare": "npm run build"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-blockchain-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A self-contained MCP server that lets AI assistants read blockchain data and prepare transactions, while users keep full custody of their keys and sign in their own wallet.",
   "main": "build/index.js",
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ function parsePort(value: string | undefined, fallback: number): number {
 }
 
 /** Current server version (single source of truth). */
-export const VERSION = '0.3.0';
+export const VERSION = '0.4.0';
 
 function parseList(value: string | undefined): string[] {
   return (value || '')
@@ -28,17 +28,21 @@ function parseList(value: string | undefined): string[] {
 
 const port = parsePort(process.env.PORT, 3000);
 
-// Where the signing page is reachable. Defaults to localhost; override
-// PUBLIC_BASE_URL when hosting the signing page behind a domain/tunnel.
-const publicBaseUrl = (process.env.PUBLIC_BASE_URL || `http://localhost:${port}`).replace(/\/$/, '');
+// An explicit public base URL, if the user pinned one (or the platform provides
+// one). When unset, the URL is derived at runtime from the port we actually
+// bind — see runtime.ts — so signing links always point at *this* server.
+const explicitPublicBaseUrl =
+  (process.env.PUBLIC_BASE_URL || process.env.RENDER_EXTERNAL_URL || '').replace(/\/$/, '') || undefined;
 
 export const config = {
-  /** Port the embedded HTTP (signing) server listens on. */
+  /** Desired port for the embedded HTTP (signing) server. */
   port,
+  /** Whether PORT was explicitly provided (affects auto-port-selection). */
+  portExplicitlySet: !!process.env.PORT,
   /** Interface to bind. Defaults to localhost only for safety. */
   host: process.env.HOST || '127.0.0.1',
-  /** Base URL used to build transaction links handed to the user. */
-  publicBaseUrl,
+  /** Explicit base URL for transaction links, or undefined to derive from the bound port. */
+  explicitPublicBaseUrl,
   /** Log verbosity: error | warn | info | debug. */
   logLevel: (process.env.LOG_LEVEL || 'info').toLowerCase(),
   /** Default chain used when a tool call omits chainId. */

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -4,6 +4,7 @@ import express, { type Request, type Response, type NextFunction } from 'express
 import { config } from '../config.js';
 import { getChains, getChainById, getRpcUrl, type Chain } from '../chains.js';
 import { logger } from '../logger.js';
+import { getPublicBaseUrl, setBoundPort } from '../runtime.js';
 import {
   getTransactionById,
   markRejected,
@@ -131,19 +132,50 @@ export function createApp(): express.Express {
 
 /**
  * Starts the embedded HTTP server. Resolves with the listening server, or
- * rejects on bind failure (e.g. the port is already in use) so the caller can
- * decide how to proceed without killing the MCP connection.
+ * rejects on bind failure so the caller can decide how to proceed without
+ * killing the MCP connection.
+ *
+ * In local (stdio) mode, when the user hasn't pinned a base URL, a busy port is
+ * not fatal: we probe the next ports and derive the signing URL from whatever
+ * we actually bind. This avoids handing out a `localhost:3000` link that lands
+ * on some other dev server. In http mode (or when PUBLIC_BASE_URL is pinned) we
+ * bind the exact port and fail on conflict, so deployments stay deterministic.
  */
+const MAX_PORT_PROBES = 20;
+
 export function startHttpServer(): Promise<http.Server> {
   const app = createApp();
   const server = http.createServer(app);
 
+  // Only auto-shift when we're free to derive the URL ourselves.
+  const allowShift = config.transport === 'stdio' && !config.explicitPublicBaseUrl;
+
   return new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(config.port, config.host, () => {
-      server.removeListener('error', reject);
-      logger.info(`Signing server listening at ${config.publicBaseUrl}`);
-      resolve(server);
-    });
+    let probes = 0;
+
+    const tryListen = (candidate: number): void => {
+      const onError = (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE' && allowShift && probes < MAX_PORT_PROBES) {
+          probes += 1;
+          const next = candidate + 1;
+          logger.warn(`Port ${candidate} is in use, trying ${next}…`);
+          tryListen(next);
+          return;
+        }
+        reject(err);
+      };
+
+      server.once('error', onError);
+      server.listen(candidate, config.host, () => {
+        server.removeListener('error', onError);
+        const address = server.address();
+        const actualPort = typeof address === 'object' && address ? address.port : candidate;
+        setBoundPort(actualPort);
+        logger.info(`Signing server listening at ${getPublicBaseUrl()}`);
+        resolve(server);
+      });
+    };
+
+    tryListen(config.port);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import type http from 'node:http';
 import { config, VERSION } from './config.js';
 import { logger } from './logger.js';
+import { getPublicBaseUrl } from './runtime.js';
 import { initStore } from './store.js';
 import { startHttpServer } from './http/server.js';
 import { startStdioServer } from './mcp/server.js';
@@ -35,7 +36,7 @@ async function main(): Promise<void> {
   if (config.transport === 'stdio') {
     await startStdioServer();
   } else {
-    logger.info(`MCP available over HTTP at ${config.publicBaseUrl}/mcp`);
+    logger.info(`MCP available over HTTP at ${getPublicBaseUrl()}/mcp`);
   }
 
   let shuttingDown = false;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { config, VERSION } from '../config.js';
+import { getPublicBaseUrl } from '../runtime.js';
 import { getChains } from '../chains.js';
 import { getBalance } from '../services/accountService.js';
 import { readContract } from '../services/contractService.js';
@@ -118,7 +119,7 @@ function registerTools(server: McpServer): void {
     async ({ chainId, to, value, data, gasLimit }) => {
       try {
         const tx = await prepareTransaction({ chainId, to, value, data, gasLimit });
-        const url = `${config.publicBaseUrl}/tx/${tx.id}`;
+        const url = `${getPublicBaseUrl()}/tx/${tx.id}`;
         return text(
           [
             'Transaction prepared. The user must open this URL to review and sign it in their wallet:',

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getPublicBaseUrl, getBoundPort, setBoundPort } from './runtime.js';
+
+test('default base URL uses the IPv4 loopback, not "localhost"', () => {
+  // Avoids dual-stack ambiguity where "localhost" resolves to ::1 first.
+  assert.match(getPublicBaseUrl(), /^http:\/\/127\.0\.0\.1:\d+$/);
+});
+
+test('base URL reflects the actually-bound port', () => {
+  setBoundPort(34567);
+  assert.equal(getBoundPort(), 34567);
+  assert.equal(getPublicBaseUrl(), 'http://127.0.0.1:34567');
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,7 +19,18 @@ export function getBoundPort(): number {
   return boundPort ?? config.port;
 }
 
-/** The base URL for signing links: an explicit override, else derived from the bound port. */
+/**
+ * The base URL for signing links: an explicit override, else derived from the
+ * interface and port we actually bound.
+ *
+ * We emit the concrete bind host (127.0.0.1) rather than "localhost". On
+ * dual-stack machines "localhost" can resolve to ::1 (IPv6) first and land on a
+ * *different* server that happens to hold the same port on the other stack
+ * (e.g. a Next.js dev server on [::]:3000), producing a confusing 404. Using
+ * the IPv4 loopback we bound removes that ambiguity.
+ */
 export function getPublicBaseUrl(): string {
-  return config.explicitPublicBaseUrl ?? `http://localhost:${getBoundPort()}`;
+  if (config.explicitPublicBaseUrl) return config.explicitPublicBaseUrl;
+  const host = config.host === '0.0.0.0' || config.host === '::' ? 'localhost' : config.host;
+  return `http://${host}:${getBoundPort()}`;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,25 @@
+import { config } from './config.js';
+
+/**
+ * Runtime state that isn't known until the server is actually listening.
+ *
+ * The signing URL handed to users must point at the port we *really* bound. In
+ * local (stdio) mode we may auto-shift off a busy port (e.g. 3000 taken by a
+ * Next.js dev server), so the public base URL is derived from the bound port
+ * unless the user pinned PUBLIC_BASE_URL explicitly.
+ */
+
+let boundPort: number | undefined;
+
+export function setBoundPort(port: number): void {
+  boundPort = port;
+}
+
+export function getBoundPort(): number {
+  return boundPort ?? config.port;
+}
+
+/** The base URL for signing links: an explicit override, else derived from the bound port. */
+export function getPublicBaseUrl(): string {
+  return config.explicitPublicBaseUrl ?? `http://localhost:${getBoundPort()}`;
+}


### PR DESCRIPTION
## Why

Two real-world reports where a prepared transaction's signing link opened a **404 "This page could not be found"** instead of the signing page. Both traced to the link's host/port not matching where the embedded signing server was actually reachable — typically because another local dev server (e.g. Next.js) was on port 3000.

## What changed

**1. Auto-select a free signing port (`8e8cc7d`)**
If the desired port is already taken, local (stdio) mode now probes the next ports and binds the first free one, then derives every signing link from the port it actually bound. `http` mode and an explicit `PUBLIC_BASE_URL` still bind deterministically and fail on conflict, so deployments stay predictable. Also accepts `RENDER_EXTERNAL_URL` as a base-URL fallback.

**2. Emit links on `127.0.0.1`, not `localhost` (`2900391`)**
A user's `lsof` revealed the subtler case: our server on IPv4 `127.0.0.1:3000` coexisting with a Next.js server on IPv6 `[::]:3000`. The bind *succeeds*, so port-probing never triggers — but the browser resolves `localhost` to `::1` (IPv6) first and lands on the other server. We now build the URL from the loopback interface we actually bind (`127.0.0.1`), removing the dual-stack ambiguity. Wildcard binds (`0.0.0.0`/`::`) still render as `localhost`.

New `src/runtime.ts` centralizes the bound-port / public-base-URL logic so the MCP tool and HTTP server agree on the link.

## Testing

- `npm test` — 9/9 pass (added `src/runtime.test.ts`)
- Reproduced the port-3000 collision with a fake server and confirmed the server shifts to 3001 and serves the signing page there
- Confirmed the server now advertises and serves on `http://127.0.0.1:<port>`

## Notes

- Version bumped to **0.4.0** (lockfile synced).
- Merging this does **not** publish to npm — that happens when a GitHub Release is created (see `.github/workflows/release.yml`).

https://claude.ai/code/session_0172kpnvEaam8ssndbN1JYNY

---
_Generated by [Claude Code](https://claude.ai/code/session_0172kpnvEaam8ssndbN1JYNY)_