### PR TITLE
feat: deploy to Vercel (stateless serverless)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,21 @@
 # MCP_ALLOWED_HOSTS=your-host.example
 # MCP_ALLOWED_ORIGINS=https://your-host.example
 
+# --- Transaction store ---
+# By default, pending transactions are kept in a local JSON file (fine for a
+# single long-running process: local, Docker, Render). For STATELESS serverless
+# (Vercel), set Redis credentials so state is shared across invocations. Either
+# the Upstash or the Vercel KV variable names work; the Vercel Marketplace
+# Upstash integration injects them automatically.
+# UPSTASH_REDIS_REST_URL=https://your-db.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your-token
+# (or KV_REST_API_URL / KV_REST_API_TOKEN)
+
 # --- Defaults ---
 # Default chain when a tool call omits chainId (11155111 = Sepolia testnet).
 # DEFAULT_CHAIN_ID=11155111
 # LOG_LEVEL=info            # error | warn | info | debug (logs go to stderr)
-# Directory for the pending-transaction store (defaults to ~/.mcp-blockchain).
+# Directory for the pending-transaction store (file backend only; defaults to ~/.mcp-blockchain).
 # MCP_DATA_DIR=
 
 # --- RPC endpoints (optional) ---

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ logs/
 
 # Typescript
 *.tsbuildinfo
+
+# Vercel
+.vercel/

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ put it behind a reverse proxy). When exposed publicly, set `MCP_ALLOWED_HOSTS`
 and/or `MCP_ALLOWED_ORIGINS` to enable DNS-rebinding protection, and front it
 with HTTPS and access control.
 
-To host it as a custom connector (Docker, one-click Render, or a quick tunnel
-for testing) and wire it into Claude's **Add custom connector** dialog, see the
-**[deployment guide](docs/deployment.md)**.
+To host it as a custom connector (one-click Render, Vercel, Docker, or a quick
+tunnel for testing) and wire it into Claude's **Add custom connector** dialog,
+see the **[deployment guide](docs/deployment.md)**. On stateless hosts like
+Vercel, point the store at Redis (`UPSTASH_REDIS_REST_URL` /
+`UPSTASH_REDIS_REST_TOKEN`) so the signing flow persists across requests.
 
 ## Tools
 
@@ -155,7 +157,8 @@ Everything is optional. Copy `.env.example` to `.env` to override defaults.
 | `PUBLIC_BASE_URL` | `http://localhost:<PORT>` | Base URL used in signing links and the `/mcp` URL (set when hosting remotely). |
 | `DEFAULT_CHAIN_ID` | `11155111` | Default chain (Sepolia testnet). |
 | `LOG_LEVEL` | `info` | `error` \| `warn` \| `info` \| `debug` (logs go to stderr). |
-| `MCP_DATA_DIR` | `~/.mcp-blockchain` | Where pending transactions are stored. |
+| `MCP_DATA_DIR` | `~/.mcp-blockchain` | Where pending transactions are stored (file backend). |
+| `UPSTASH_REDIS_REST_URL` / `_TOKEN` | — | Use a Redis store instead of the file backend. Required on stateless hosts (Vercel). `KV_REST_API_URL` / `_TOKEN` also work. |
 | `RPC_URL_<chainId>` | built-in public RPC | Override the RPC for a chain, e.g. `RPC_URL_1=https://…`. |
 | `INFURA_API_KEY` | — | If set, upgrades default RPCs to Infura. |
 | `ETHERSCAN_API_KEY` | — | If set, `read-contract` can auto-fetch verified ABIs. |

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,32 @@
+// Vercel serverless entry point.
+//
+// Vercel runs `npm run build` (see vercel.json) to compile TypeScript into
+// build/, then bundles this function. We reuse the exact same Express app that
+// the container/stdio modes use — the app is stateless (stateless MCP transport
+// + Redis store), so it is safe to (re)create per cold start and share across
+// invocations on a warm instance.
+//
+// All routes (/mcp, /tx/:id, /api/*) are rewritten to this function; Express
+// dispatches on the original request URL.
+import { createApp } from '../build/http/server.js';
+import { initStore } from '../build/store.js';
+
+let appPromise;
+
+function getApp() {
+  if (!appPromise) {
+    appPromise = initStore()
+      .then(() => createApp())
+      .catch((error) => {
+        // Reset so the next invocation retries init rather than caching failure.
+        appPromise = undefined;
+        throw error;
+      });
+  }
+  return appPromise;
+}
+
+export default async function handler(req, res) {
+  const app = await getApp();
+  app(req, res);
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,6 +79,34 @@ Railway, …) inject their own `PORT`; the server honors it.
 
 ---
 
+## Option D — Vercel (serverless)
+
+Vercel runs the server as **stateless serverless functions** rather than a
+long-lived process, so it needs a shared store for pending transactions. The
+repo is preconfigured for this — [`vercel.json`](../vercel.json) builds the
+project and routes every request (`/mcp`, `/tx/<id>`, `/api/*`) to one function.
+
+1. **Add a Redis store (free).** In your Vercel project: **Storage → Create
+   Database → Upstash for Redis** (free plan). Connecting it injects
+   `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` (a.k.a.
+   `KV_REST_API_URL` / `KV_REST_API_TOKEN`) into the project automatically — the
+   server reads either pair. Without this, reads succeed but the signing flow
+   (`prepare-transaction` → sign → status) can't persist across requests.
+2. **Import the repo.** **Add New → Project**, select this repo, deploy. No
+   build settings to change — `vercel.json` handles the build and routing.
+3. **Base URL is automatic.** The server derives signing links from Vercel's
+   `VERCEL_PROJECT_PRODUCTION_URL`, so you usually don't need `PUBLIC_BASE_URL`.
+   (Set it explicitly if you use a custom domain.)
+
+Your connector URL: `https://<your-project>.vercel.app/mcp`
+
+> Notes: the `/mcp` endpoint is **stateless** (POST only — a `GET` returns 405,
+> which is expected). Transaction confirmation is reconciled lazily when the
+> status is polled, since serverless can't run a background watcher. Pending
+> entries expire from Redis after 7 days.
+
+---
+
 ## Connect it in Claude
 
 In the **"Add custom connector"** dialog:
@@ -101,7 +129,8 @@ the tools are available.
 | `MCP_TRANSPORT` | `http` (the Docker image sets this) |
 | `HOST` | `0.0.0.0` (the Docker image sets this) |
 | `PORT` | Usually injected by the platform; defaults to `3000`. |
-| `PUBLIC_BASE_URL` | Your public `https://…` URL. Auto-derived on Render. **Required elsewhere** for working signing links. |
+| `PUBLIC_BASE_URL` | Your public `https://…` URL. Auto-derived on Render and Vercel. **Required elsewhere** for working signing links. |
+| `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` | Redis store credentials. **Required on Vercel** (or any stateless/multi-instance host); auto-injected by Vercel's Upstash integration. `KV_REST_API_URL` / `KV_REST_API_TOKEN` also accepted. |
 | `MCP_ALLOWED_HOSTS` | Optional. Comma-separated hostnames to accept on `/mcp` (enables DNS-rebind protection). |
 | `MCP_ALLOWED_ORIGINS` | Optional. Comma-separated allowed `Origin` values. |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@upstash/redis": "^1.38.0",
         "dotenv": "^16.4.5",
         "ethers": "^6.16.0",
         "express": "^4.21.2",
@@ -970,6 +971,15 @@
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/accepts": {
@@ -2235,6 +2245,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@upstash/redis": "^1.38.0",
     "dotenv": "^16.4.5",
     "ethers": "^6.16.0",
     "express": "^4.21.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,11 +28,17 @@ function parseList(value: string | undefined): string[] {
 
 const port = parsePort(process.env.PORT, 3000);
 
+// Vercel exposes the deployment host (no scheme) rather than a full URL. Prefer
+// the stable production domain over the per-deployment URL.
+const vercelHost = process.env.VERCEL_PROJECT_PRODUCTION_URL || process.env.VERCEL_URL;
+const vercelBaseUrl = vercelHost ? `https://${vercelHost}` : '';
+
 // An explicit public base URL, if the user pinned one (or the platform provides
 // one). When unset, the URL is derived at runtime from the port we actually
 // bind — see runtime.ts — so signing links always point at *this* server.
 const explicitPublicBaseUrl =
-  (process.env.PUBLIC_BASE_URL || process.env.RENDER_EXTERNAL_URL || '').replace(/\/$/, '') || undefined;
+  (process.env.PUBLIC_BASE_URL || process.env.RENDER_EXTERNAL_URL || vercelBaseUrl || '').replace(/\/$/, '') ||
+  undefined;
 
 export const config = {
   /** Desired port for the embedded HTTP (signing) server. */

--- a/src/http/mcpHttp.ts
+++ b/src/http/mcpHttp.ts
@@ -1,19 +1,21 @@
-import { randomUUID } from 'node:crypto';
 import type { Express, Request, Response } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { config } from '../config.js';
 import { logger } from '../logger.js';
 import { createMcpServer } from '../mcp/server.js';
 
 /**
- * Mounts the MCP Streamable HTTP transport at `/mcp` on an existing Express
- * app, so remote/web MCP clients can use the server over HTTP (in addition to,
- * or instead of, stdio). Uses the standard stateful pattern: an `initialize`
- * request creates a session; later requests carry the `mcp-session-id` header.
+ * Mounts the MCP Streamable HTTP transport at `/mcp` on an existing Express app,
+ * so remote/web MCP clients can use the server over HTTP (in addition to, or
+ * instead of, stdio).
+ *
+ * This uses the transport's **stateless** mode: every POST spins up a fresh
+ * server + transport, handles the single JSON-RPC request, and tears down. All
+ * of this server's tools are plain request/response (no server-initiated
+ * notifications), so nothing is lost — and it works identically on a long-lived
+ * container and on stateless serverless (Vercel), where an in-memory session map
+ * would not survive between requests.
  */
-
-const transports = new Map<string, StreamableHTTPServerTransport>();
 
 function setCors(res: Response): void {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -30,41 +32,24 @@ export function mountMcpEndpoint(app: Express): void {
 
   app.post('/mcp', async (req: Request, res: Response) => {
     setCors(res);
+
+    const dnsProtection = config.mcpAllowedHosts.length > 0 || config.mcpAllowedOrigins.length > 0;
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined, // stateless: no session is created or tracked
+      enableDnsRebindingProtection: dnsProtection,
+      allowedHosts: dnsProtection ? config.mcpAllowedHosts : undefined,
+      allowedOrigins: dnsProtection ? config.mcpAllowedOrigins : undefined,
+    });
+    const server = createMcpServer();
+
+    // Tear down per-request resources once the response is done.
+    res.on('close', () => {
+      void transport.close();
+      void server.close();
+    });
+
     try {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      let transport = sessionId ? transports.get(sessionId) : undefined;
-
-      if (!transport) {
-        // A new session may only begin with an `initialize` request.
-        if (sessionId || !isInitializeRequest(req.body)) {
-          res.status(400).json({
-            jsonrpc: '2.0',
-            error: { code: -32000, message: 'No valid session. Send an initialize request first.' },
-            id: null,
-          });
-          return;
-        }
-
-        const dnsProtection = config.mcpAllowedHosts.length > 0 || config.mcpAllowedOrigins.length > 0;
-        const newTransport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: () => randomUUID(),
-          enableDnsRebindingProtection: dnsProtection,
-          allowedHosts: dnsProtection ? config.mcpAllowedHosts : undefined,
-          allowedOrigins: dnsProtection ? config.mcpAllowedOrigins : undefined,
-          onsessioninitialized: (sid) => {
-            transports.set(sid, newTransport);
-            logger.info(`MCP HTTP session opened: ${sid}`);
-          },
-        });
-        newTransport.onclose = () => {
-          const sid = newTransport.sessionId;
-          if (sid && transports.delete(sid)) logger.info(`MCP HTTP session closed: ${sid}`);
-        };
-
-        await createMcpServer().connect(newTransport);
-        transport = newTransport;
-      }
-
+      await server.connect(transport);
       await transport.handleRequest(req, res, req.body);
     } catch (error) {
       logger.error('Error handling MCP POST', error);
@@ -78,19 +63,18 @@ export function mountMcpEndpoint(app: Express): void {
     }
   });
 
-  // GET (SSE stream) and DELETE (session teardown) reuse the session transport.
-  const handleSession = async (req: Request, res: Response) => {
+  // In stateless mode there is no session to attach an SSE stream to, and no
+  // session to delete. Report that clearly rather than hanging.
+  const notAllowed = (_req: Request, res: Response) => {
     setCors(res);
-    const sessionId = req.headers['mcp-session-id'] as string | undefined;
-    const transport = sessionId ? transports.get(sessionId) : undefined;
-    if (!transport) {
-      res.status(400).send('Invalid or missing session ID');
-      return;
-    }
-    await transport.handleRequest(req, res);
+    res.status(405).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Method not allowed: this endpoint is stateless (POST only).' },
+      id: null,
+    });
   };
-  app.get('/mcp', handleSession);
-  app.delete('/mcp', handleSession);
+  app.get('/mcp', notAllowed);
+  app.delete('/mcp', notAllowed);
 
-  logger.info('Mounted MCP Streamable HTTP endpoint at /mcp');
+  logger.info('Mounted MCP Streamable HTTP endpoint at /mcp (stateless)');
 }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -33,8 +33,8 @@ function chainView(chain: Chain) {
   };
 }
 
-function txView(id: string) {
-  const tx = getTransactionById(id);
+async function txView(id: string) {
+  const tx = await getTransactionById(id);
   if (!tx) return undefined;
   return {
     id: tx.id,
@@ -54,7 +54,15 @@ function txView(id: string) {
 export function createApp(): express.Express {
   const app = express();
   app.disable('x-powered-by');
-  app.use(express.json({ limit: '1mb' }));
+
+  // Parse JSON bodies — but skip it when the body is already parsed. On Vercel
+  // the serverless runtime consumes the request stream and populates req.body;
+  // running express.json() again would block waiting on an exhausted stream.
+  const parseJson = express.json({ limit: '1mb' });
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    if (req.body !== undefined) return next();
+    parseJson(req, res, next);
+  });
 
   // MCP over Streamable HTTP, for remote/web clients (alongside stdio).
   mountMcpEndpoint(app);
@@ -77,8 +85,8 @@ export function createApp(): express.Express {
     res.json({ chains: getChains().map(chainView) });
   });
 
-  app.get('/api/tx/:id', (req, res) => {
-    const tx = txView(req.params.id);
+  app.get('/api/tx/:id', async (req, res) => {
+    const tx = await txView(req.params.id);
     if (!tx) return res.status(404).json({ error: 'Transaction not found.' });
     const chain = getChainById(tx.chainId);
     if (!chain) return res.status(500).json({ error: 'Unknown chain for transaction.' });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -152,7 +152,7 @@ function registerTools(server: McpServer): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ id }) => {
-      const tx = getTransactionById(id);
+      const tx = await getTransactionById(id);
       if (!tx) return errorText(`Transaction ${id} not found.`);
       return text(
         JSON.stringify(

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -9,6 +9,34 @@ import {
   type StoredTransaction,
 } from '../store.js';
 
+/**
+ * Reconciles a SUBMITTED transaction with the chain: if its receipt is now
+ * available, advances it to CONFIRMED or FAILED. This is a non-blocking,
+ * read-time check (the receipt is fetched once, not awaited-until-mined) so it
+ * works on stateless serverless hosts where no background task can run after a
+ * response is sent. Idempotent and safe to call on any status.
+ */
+async function reconcileStatus(tx: StoredTransaction): Promise<StoredTransaction> {
+  if (tx.status !== 'SUBMITTED' || !tx.txHash) return tx;
+  try {
+    const provider = getProvider(tx.chainId);
+    const receipt = await provider.getTransactionReceipt(tx.txHash);
+    if (!receipt) return tx; // not mined yet
+
+    const patch =
+      receipt.status === 1
+        ? { status: 'CONFIRMED' as const }
+        : { status: 'FAILED' as const, error: 'Transaction reverted on-chain.' };
+    const updated = await updateTransaction(tx.id, patch);
+    if (updated) logger.info(`Transaction ${tx.id} reconciled to ${updated.status} (${tx.txHash})`);
+    return updated ?? tx;
+  } catch (error) {
+    // A transient RPC error shouldn't change the stored status; report it next poll.
+    logger.warn(`Could not reconcile transaction ${tx.id}`, error);
+    return tx;
+  }
+}
+
 export interface PrepareTransactionInput {
   chainId: string;
   to: string;
@@ -79,9 +107,13 @@ export async function prepareTransaction(input: PrepareTransactionInput): Promis
   return tx;
 }
 
-/** Returns a stored transaction by id. */
-export function getTransactionById(id: string): StoredTransaction | undefined {
-  return getTransaction(id);
+/**
+ * Returns a stored transaction by id, reconciling its status against the chain
+ * first (so a SUBMITTED tx that has since been mined surfaces as CONFIRMED).
+ */
+export async function getTransactionById(id: string): Promise<StoredTransaction | undefined> {
+  const tx = await getTransaction(id);
+  return tx ? reconcileStatus(tx) : undefined;
 }
 
 /**
@@ -93,7 +125,7 @@ export async function markSubmitted(
   txHash: string,
   from?: string,
 ): Promise<StoredTransaction> {
-  const tx = getTransaction(id);
+  const tx = await getTransaction(id);
   if (!tx) throw new Error(`Transaction ${id} not found.`);
   if (tx.status !== 'PENDING') {
     throw new Error(`Transaction ${id} is already ${tx.status} and cannot be submitted again.`);
@@ -108,37 +140,17 @@ export async function markSubmitted(
     from: from ? toChecksumAddress(from) : tx.from,
   });
 
-  // Watch for confirmation without blocking the caller.
-  void watchConfirmation(id, txHash, tx.chainId);
+  // Confirmation is reconciled lazily on the next status read (see
+  // reconcileStatus) so the flow works on stateless serverless hosts.
   return updated!;
 }
 
 /** Marks a pending transaction as rejected by the user. */
 export async function markRejected(id: string): Promise<StoredTransaction> {
-  const tx = getTransaction(id);
+  const tx = await getTransaction(id);
   if (!tx) throw new Error(`Transaction ${id} not found.`);
   if (tx.status !== 'PENDING') {
     throw new Error(`Transaction ${id} is already ${tx.status} and cannot be rejected.`);
   }
   return (await updateTransaction(id, { status: 'REJECTED' }))!;
-}
-
-/** Waits for the transaction to be mined and updates its final status. */
-async function watchConfirmation(id: string, txHash: string, chainId: string): Promise<void> {
-  try {
-    const provider = getProvider(chainId);
-    const receipt = await provider.waitForTransaction(txHash);
-
-    if (receipt && receipt.status === 1) {
-      await updateTransaction(id, { status: 'CONFIRMED' });
-      logger.info(`Transaction ${id} confirmed (${txHash})`);
-    } else {
-      await updateTransaction(id, { status: 'FAILED', error: 'Transaction reverted on-chain.' });
-      logger.warn(`Transaction ${id} reverted (${txHash})`);
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    await updateTransaction(id, { status: 'FAILED', error: message });
-    logger.error(`Error watching confirmation for ${id}`, error);
-  }
 }

--- a/src/storage/fileBackend.ts
+++ b/src/storage/fileBackend.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { logger } from '../logger.js';
+import type { StoreBackend, StoredTransaction } from './types.js';
+
+/**
+ * Zero-dependency, file-backed transaction store.
+ *
+ * Pending transactions are kept in an in-memory map and mirrored to a single
+ * JSON file so they survive restarts. There is no database server to install.
+ * Writes are serialized and written atomically (temp file + rename). Suitable
+ * for any single long-running process; not for stateless serverless.
+ */
+export class FileBackend implements StoreBackend {
+  private readonly filePath: string;
+  private readonly transactions = new Map<string, StoredTransaction>();
+  // Serializes file writes so concurrent updates can't interleave/corrupt the file.
+  private writeChain: Promise<void> = Promise.resolve();
+  private initialized = false;
+
+  constructor(private readonly dataDir: string) {
+    this.filePath = path.join(dataDir, 'transactions.json');
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    await fs.mkdir(this.dataDir, { recursive: true });
+
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as StoredTransaction[];
+      for (const tx of parsed) this.transactions.set(tx.id, tx);
+      logger.info(`Loaded ${this.transactions.size} transaction(s) from ${this.filePath}`);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        logger.info(`No existing transaction store; will create ${this.filePath}`);
+      } else {
+        // Corrupt file shouldn't crash the server — start empty and warn.
+        logger.warn(`Could not read transaction store, starting empty`, error);
+      }
+    }
+  }
+
+  private persist(): Promise<void> {
+    const snapshot = JSON.stringify([...this.transactions.values()], null, 2);
+    const tmp = `${this.filePath}.tmp`;
+    this.writeChain = this.writeChain
+      .then(() => fs.writeFile(tmp, snapshot, 'utf8'))
+      .then(() => fs.rename(tmp, this.filePath))
+      .catch((error) => logger.error('Failed to persist transaction store', error));
+    return this.writeChain;
+  }
+
+  async create(tx: StoredTransaction): Promise<StoredTransaction> {
+    this.transactions.set(tx.id, tx);
+    await this.persist();
+    return tx;
+  }
+
+  async get(id: string): Promise<StoredTransaction | undefined> {
+    return this.transactions.get(id);
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<StoredTransaction, 'id' | 'createdAt'>>,
+  ): Promise<StoredTransaction | undefined> {
+    const existing = this.transactions.get(id);
+    if (!existing) return undefined;
+
+    const updated: StoredTransaction = { ...existing, ...patch };
+    this.transactions.set(id, updated);
+    await this.persist();
+    return updated;
+  }
+
+  async list(): Promise<StoredTransaction[]> {
+    return [...this.transactions.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+}

--- a/src/storage/redisBackend.test.ts
+++ b/src/storage/redisBackend.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { redisConfigFromEnv } from './redisBackend.js';
+
+const ENV_KEYS = [
+  'UPSTASH_REDIS_REST_URL',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'KV_REST_API_URL',
+  'KV_REST_API_TOKEN',
+] as const;
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+test('returns undefined when no Redis credentials are present', () => {
+  clearEnv();
+  assert.equal(redisConfigFromEnv(), undefined);
+});
+
+test('reads the Upstash env names', () => {
+  clearEnv();
+  process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'token-a';
+  assert.deepEqual(redisConfigFromEnv(), {
+    url: 'https://example.upstash.io',
+    token: 'token-a',
+  });
+  clearEnv();
+});
+
+test('falls back to the Vercel KV env names', () => {
+  clearEnv();
+  process.env.KV_REST_API_URL = 'https://kv.example.io';
+  process.env.KV_REST_API_TOKEN = 'token-b';
+  assert.deepEqual(redisConfigFromEnv(), {
+    url: 'https://kv.example.io',
+    token: 'token-b',
+  });
+  clearEnv();
+});
+
+test('requires both url and token', () => {
+  clearEnv();
+  process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+  assert.equal(redisConfigFromEnv(), undefined);
+  clearEnv();
+});

--- a/src/storage/redisBackend.ts
+++ b/src/storage/redisBackend.ts
@@ -1,0 +1,91 @@
+import { Redis } from '@upstash/redis';
+import { logger } from '../logger.js';
+import type { StoreBackend, StoredTransaction } from './types.js';
+
+/**
+ * Redis-backed store for stateless/serverless deployments (Vercel).
+ *
+ * Each transaction is a JSON value at `tx:<id>`; a sorted set `tx:index` keeps
+ * ids ordered by creation time so {@link list} works without scanning keys.
+ * Keys carry a TTL so abandoned pending entries (which anyone with the public
+ * URL could create) clean themselves up.
+ *
+ * Uses Upstash's REST client, which works inside short-lived serverless
+ * invocations where holding a TCP connection isn't viable. Provisioning Upstash
+ * via the Vercel Marketplace injects the credentials this reads.
+ */
+
+const KEY_PREFIX = 'tx:';
+const INDEX_KEY = 'tx:index';
+/** Abandoned/junk pending entries expire after this many seconds (7 days). */
+const TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/** Reads Upstash credentials from either the Upstash or Vercel KV env names. */
+export function redisConfigFromEnv(): { url: string; token: string } | undefined {
+  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
+  return url && token ? { url, token } : undefined;
+}
+
+export class RedisBackend implements StoreBackend {
+  private readonly redis: Redis;
+
+  constructor(config: { url: string; token: string }) {
+    this.redis = new Redis({ url: config.url, token: config.token });
+  }
+
+  private key(id: string): string {
+    return `${KEY_PREFIX}${id}`;
+  }
+
+  async init(): Promise<void> {
+    // Verify connectivity early so misconfiguration fails loudly at startup
+    // rather than on the first tool call.
+    await this.redis.ping();
+    logger.info('Connected to Redis transaction store');
+  }
+
+  async create(tx: StoredTransaction): Promise<StoredTransaction> {
+    const score = Date.parse(tx.createdAt) || 0;
+    await Promise.all([
+      this.redis.set(this.key(tx.id), tx, { ex: TTL_SECONDS }),
+      this.redis.zadd(INDEX_KEY, { score, member: tx.id }),
+    ]);
+    return tx;
+  }
+
+  async get(id: string): Promise<StoredTransaction | undefined> {
+    const tx = await this.redis.get<StoredTransaction>(this.key(id));
+    return tx ?? undefined;
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<StoredTransaction, 'id' | 'createdAt'>>,
+  ): Promise<StoredTransaction | undefined> {
+    const existing = await this.get(id);
+    if (!existing) return undefined;
+
+    const updated: StoredTransaction = { ...existing, ...patch };
+    await this.redis.set(this.key(id), updated, { ex: TTL_SECONDS });
+    return updated;
+  }
+
+  async list(): Promise<StoredTransaction[]> {
+    const ids = await this.redis.zrange<string[]>(INDEX_KEY, 0, -1, { rev: true });
+    if (ids.length === 0) return [];
+
+    const records = await this.redis.mget<StoredTransaction[]>(...ids.map((id) => this.key(id)));
+    const live: StoredTransaction[] = [];
+    const expired: string[] = [];
+    ids.forEach((id, i) => {
+      const tx = records[i];
+      if (tx) live.push(tx);
+      else expired.push(id);
+    });
+
+    // Drop index entries whose values have aged out, so the index stays bounded.
+    if (expired.length > 0) await this.redis.zrem(INDEX_KEY, ...expired);
+    return live;
+  }
+}

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Storage backend abstraction for pending transactions.
+ *
+ * The server runs in two very different environments:
+ *  - A single long-running process (local stdio, Docker, Render) where an
+ *    in-memory map mirrored to a JSON file is enough — see {@link FileBackend}.
+ *  - Stateless serverless functions (Vercel) where each request may hit a fresh
+ *    instance with no shared memory or persistent disk, so state must live in an
+ *    external store — see the Redis backend.
+ *
+ * Both implement this interface; {@link selectBackend} picks one from the
+ * environment so the rest of the app is storage-agnostic.
+ */
+
+export type TxStatus = 'PENDING' | 'SUBMITTED' | 'CONFIRMED' | 'FAILED' | 'REJECTED';
+
+export interface StoredTransaction {
+  id: string;
+  chainId: string;
+  to: string;
+  from?: string;
+  /** Human-readable amount in the native token, e.g. "0.01". */
+  valueDisplay: string;
+  /** Amount in wei as minimal hex, ready for `eth_sendTransaction`. */
+  valueWeiHex: string;
+  /** Calldata, defaults to "0x". */
+  data: string;
+  /** Optional gas limit as minimal hex. */
+  gasLimitHex?: string;
+  status: TxStatus;
+  txHash?: string;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StoreBackend {
+  /** Prepares the backend (load from disk, ping the remote, …). Idempotent. */
+  init(): Promise<void>;
+  /** Inserts a new transaction. */
+  create(tx: StoredTransaction): Promise<StoredTransaction>;
+  /** Returns a transaction by id, or undefined. */
+  get(id: string): Promise<StoredTransaction | undefined>;
+  /** Applies a partial update (the caller sets updatedAt). Returns the new record, or undefined if missing. */
+  update(
+    id: string,
+    patch: Partial<Omit<StoredTransaction, 'id' | 'createdAt'>>,
+  ): Promise<StoredTransaction | undefined>;
+  /** Returns all transactions, most recent first. */
+  list(): Promise<StoredTransaction[]>;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -29,7 +29,7 @@ test('create, get and persist a transaction', async () => {
   await store.initStore();
   await store.createTransaction(sample('id-1'));
 
-  const got = store.getTransaction('id-1');
+  const got = await store.getTransaction('id-1');
   assert.equal(got?.status, 'PENDING');
 
   const onDisk = JSON.parse(readFileSync(path.join(dir, 'transactions.json'), 'utf8'));
@@ -39,7 +39,7 @@ test('create, get and persist a transaction', async () => {
 
 test('update mutates status and bumps updatedAt', async () => {
   await store.createTransaction(sample('id-2'));
-  const before = store.getTransaction('id-2')!.updatedAt;
+  const before = (await store.getTransaction('id-2'))!.updatedAt;
   await new Promise((r) => setTimeout(r, 5));
 
   const updated = await store.updateTransaction('id-2', { status: 'CONFIRMED', txHash: '0xabc' });
@@ -54,7 +54,7 @@ test('updating a missing transaction returns undefined', async () => {
 });
 
 test('listTransactions returns most-recent first', async () => {
-  const all = store.listTransactions();
+  const all = await store.listTransactions();
   assert.ok(all.length >= 2);
   for (let i = 1; i < all.length; i++) {
     assert.ok(all[i - 1].createdAt >= all[i].createdAt);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,87 +1,49 @@
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import { config } from './config.js';
 import { logger } from './logger.js';
+import { FileBackend } from './storage/fileBackend.js';
+import { RedisBackend, redisConfigFromEnv } from './storage/redisBackend.js';
+import type { StoreBackend, StoredTransaction } from './storage/types.js';
 
 /**
- * Zero-dependency, file-backed transaction store.
+ * Public transaction-store API.
  *
- * Pending transactions are kept in an in-memory map and mirrored to a single
- * JSON file so they survive restarts. There is no database server to install.
- * Writes are serialized and written atomically (temp file + rename).
+ * This is a thin facade over a pluggable {@link StoreBackend}: a file-backed
+ * store for single-process deployments (local, Docker, Render) and a Redis store
+ * for stateless serverless (Vercel). The backend is chosen from the environment
+ * — if Redis credentials are present they win — so callers never care which is
+ * in use.
  */
 
-export type TxStatus = 'PENDING' | 'SUBMITTED' | 'CONFIRMED' | 'FAILED' | 'REJECTED';
+export type { StoredTransaction, TxStatus } from './storage/types.js';
 
-export interface StoredTransaction {
-  id: string;
-  chainId: string;
-  to: string;
-  from?: string;
-  /** Human-readable amount in the native token, e.g. "0.01". */
-  valueDisplay: string;
-  /** Amount in wei as minimal hex, ready for `eth_sendTransaction`. */
-  valueWeiHex: string;
-  /** Calldata, defaults to "0x". */
-  data: string;
-  /** Optional gas limit as minimal hex. */
-  gasLimitHex?: string;
-  status: TxStatus;
-  txHash?: string;
-  error?: string;
-  createdAt: string;
-  updatedAt: string;
-}
+let backend: StoreBackend | undefined;
 
-const filePath = path.join(config.dataDir, 'transactions.json');
-const transactions = new Map<string, StoredTransaction>();
-
-// Serializes file writes so concurrent updates can't interleave/corrupt the file.
-let writeChain: Promise<void> = Promise.resolve();
-let initialized = false;
-
-/** Loads any persisted transactions from disk. Safe to call more than once. */
-export async function initStore(): Promise<void> {
-  if (initialized) return;
-  initialized = true;
-
-  await fs.mkdir(config.dataDir, { recursive: true });
-
-  try {
-    const raw = await fs.readFile(filePath, 'utf8');
-    const parsed = JSON.parse(raw) as StoredTransaction[];
-    for (const tx of parsed) transactions.set(tx.id, tx);
-    logger.info(`Loaded ${transactions.size} transaction(s) from ${filePath}`);
-  } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      logger.info(`No existing transaction store; will create ${filePath}`);
-    } else {
-      // Corrupt file shouldn't crash the server — start empty and warn.
-      logger.warn(`Could not read transaction store, starting empty`, error);
-    }
+function getBackend(): StoreBackend {
+  if (backend) return backend;
+  const redisConfig = redisConfigFromEnv();
+  if (redisConfig) {
+    logger.info('Using Redis transaction store');
+    backend = new RedisBackend(redisConfig);
+  } else {
+    logger.info('Using file transaction store');
+    backend = new FileBackend(config.dataDir);
   }
+  return backend;
 }
 
-function persist(): Promise<void> {
-  const snapshot = JSON.stringify([...transactions.values()], null, 2);
-  const tmp = `${filePath}.tmp`;
-  writeChain = writeChain
-    .then(() => fs.writeFile(tmp, snapshot, 'utf8'))
-    .then(() => fs.rename(tmp, filePath))
-    .catch((error) => logger.error('Failed to persist transaction store', error));
-  return writeChain;
+/** Prepares the configured store. Safe to call more than once. */
+export async function initStore(): Promise<void> {
+  await getBackend().init();
 }
 
 /** Inserts a new transaction and persists it. */
 export async function createTransaction(tx: StoredTransaction): Promise<StoredTransaction> {
-  transactions.set(tx.id, tx);
-  await persist();
-  return tx;
+  return getBackend().create(tx);
 }
 
 /** Returns a transaction by id, or undefined. */
-export function getTransaction(id: string): StoredTransaction | undefined {
-  return transactions.get(id);
+export async function getTransaction(id: string): Promise<StoredTransaction | undefined> {
+  return getBackend().get(id);
 }
 
 /** Applies a partial update (bumping updatedAt) and persists. Returns the new record. */
@@ -89,20 +51,10 @@ export async function updateTransaction(
   id: string,
   patch: Partial<Omit<StoredTransaction, 'id' | 'createdAt'>>,
 ): Promise<StoredTransaction | undefined> {
-  const existing = transactions.get(id);
-  if (!existing) return undefined;
-
-  const updated: StoredTransaction = {
-    ...existing,
-    ...patch,
-    updatedAt: new Date().toISOString(),
-  };
-  transactions.set(id, updated);
-  await persist();
-  return updated;
+  return getBackend().update(id, { ...patch, updatedAt: new Date().toISOString() });
 }
 
 /** Returns all transactions (most recent first). */
-export function listTransactions(): StoredTransaction[] {
-  return [...transactions.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+export async function listTransactions(): Promise<StoredTransaction[]> {
+  return getBackend().list();
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "functions": {
+    "api/index.js": {
+      "maxDuration": 60
+    }
+  },
+  "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
+}


### PR DESCRIPTION
## What & why

Makes the MCP server deployable on **Vercel's serverless runtime** at \$0 (free Hobby plan + free Upstash Redis), while keeping local stdio and Render/Docker container modes working unchanged.

Two serverless realities drove the design:
1. **No shared memory across invocations** → the in-memory MCP session map and the in-memory/file transaction store don't survive.
2. **No background work after a response** → the fire-and-forget confirmation watcher never completes.

## Changes

- **Stateless MCP transport** (`src/http/mcpHttp.ts`): `/mcp` now creates a fresh server + transport per request (`sessionIdGenerator: undefined`). All 5 tools are request/response, so no functionality is lost — and it simplifies container mode too. `GET`/`DELETE /mcp` return 405 (no session to attach to).
- **Pluggable store** (`src/storage/`): `FileBackend` (local/Render) + `RedisBackend` (Upstash REST, free tier). Selected from env — Redis wins when `UPSTASH_REDIS_REST_URL`/`KV_REST_API_URL` are present, else file. `store.ts` is now a thin async facade. Redis keys carry a 7-day TTL so abandoned pending entries self-clean.
- **Lazy confirmation** (`src/services/transactionService.ts`): replaced the background `watchConfirmation` with `reconcileStatus` on read — a `SUBMITTED` tx advances to `CONFIRMED`/`FAILED` on the next status poll. Works on every host. Store reads are async end-to-end.
- **Vercel wiring**: `api/index.js` (wraps the existing Express app) + `vercel.json` (build + catch-all routing). `config.ts` derives `PUBLIC_BASE_URL` from `VERCEL_PROJECT_PRODUCTION_URL`/`VERCEL_URL`. `express.json` guarded so Vercel's pre-parsed body isn't double-read.
- **Docs/tests**: Vercel option in `docs/deployment.md`, env vars in README/.env.example; tests for the new env detection and the async store API.

## New dependency

`@upstash/redis` (small, REST-based, free-tier) — required for shared state on serverless. The 3 npm-audit findings are pre-existing (ethers), not from this dep.

## Verification

- `npm run typecheck`, `npm run build`, `npm test` → **13/13 pass**.
- Local end-to-end against the refactored stateless transport: `initialize`, `tools/list`, `prepare-transaction` (write) → `get-transaction-status` (read) across **separate** stateless requests, `/api/tx/:id`, and `GET /mcp → 405`. All correct.

## Deploy steps (for the maintainer)

1. Vercel project → **Storage → Upstash for Redis** (free) — auto-injects credentials.
2. **Import repo** → deploy (no settings to change; `vercel.json` handles it).
3. Connector URL: `https://<project>.vercel.app/mcp` (OAuth fields blank — authless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)